### PR TITLE
fix(go.mod): Match module name w/ Github repo

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/ethpandaops/blob-spammer
+module github.com/ethpandaops/goomy-blob
 
 go 1.21.1
 


### PR DESCRIPTION
One other small issue I hit trying to `go install`:

```
$ go install github.com/ethpandaops/goomy-blob/cmd/blob-sender@latest
go: downloading github.com/ethpandaops/goomy-blob v0.0.0-20240117191701-98462cb198aa
go: github.com/ethpandaops/goomy-blob/cmd/blob-sender@latest: version constraints conflict:
	github.com/ethpandaops/goomy-blob@v0.0.0-20240117191701-98462cb198aa: parsing go.mod:
	module declares its path as: github.com/ethpandaops/blob-spammer
	        but was required as: github.com/ethpandaops/goomy-blob
```

This is because the `module` field in go.mod doesn't match the Github repo name.  Unfortunately I can't fully test this since my fork by definition also has a different repo name, but hopefully this is the last "blocker" to using `go install` 🤞.